### PR TITLE
Fix CI for upload-artifact action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,7 +163,7 @@ jobs:
 
       - name: Upload logfiles
         if: failure()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.LOGFILE }}
           path: logs/*/*.log


### PR DESCRIPTION
Update the version from v2 to v4 since the older version has been deprecated.