### PR TITLE
Update ci.yml to use org as approvers for outside PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,8 +75,8 @@ jobs:
         uses: trstringer/manual-approval@v1
         timeout-minutes: 1440
         with:
-          secret: ${{ secrets.GITHUB_TOKEN }}
-          approvers: ${{ join(github.event.pull_request.requested_reviewers.*.login, ', ') }}
+          secret: ${{ secrets.VDODEVEL }}
+          approvers: dm-vdo
           minimum-approvals: 1
           issue-title: "Verifying pull request for testing"
           issue-body: "Please approve or deny the testing of this pull request."


### PR DESCRIPTION
Outside PRs will never run automatically. Instead, we ask for one of the team to check the PR to make sure the code is not malicious. If its not they can use a special issue created by the CI to allow for the automatic testing. This change switches from using the person on Triage to the entire organization.